### PR TITLE
Fix: Persist nozzle configuration in local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A web-based calculator for determining pressure loss through drill bit nozzles a
 This application provides real-time calculations for:
 - Pressure loss through drill bit nozzles
 - Hydraulic Horsepower per Square Inch (HSI)
+- Jet Impact Force (JIF)
 - Support for multiple nozzle configurations
 - Flow rate optimization
 
@@ -41,7 +42,34 @@ Where:
 - HSI = Hydraulic Horsepower per Square Inch
 - Pressure Loss = Pressure loss through bit (psi)
 - Q = Flow Rate (gpm)
-- Bit Area = Area of the drill bit (in²)
+- Bit Area = Area of the drill bit (in²) (Note: In the app, Bit Size (diameter) is used, and area is calculated (πd²/4), though this formula typically uses bit area directly)
+
+### Jet Impact Force (JIF)
+
+Jet Impact Force is a measure of the hydraulic energy from the drilling fluid jets exiting the bit nozzles. This force helps clean the bottom of the wellbore and can influence the rate of penetration (ROP). It is calculated in pounds (lbs).
+
+The formulas used in this application are:
+
+1.  **Nozzle Velocity (Vn):**
+    ```
+    Vn (ft/s) = 0.32086 × Q (gpm) / TFA (in²)
+    ```
+    Where:
+    - Vn = Nozzle Velocity in feet per second
+    - Q = Flow Rate in gallons per minute
+    - TFA = Total Flow Area in square inches (calculated from nozzle sizes or direct input)
+
+2.  **Jet Impact Force (JIF):**
+    ```
+    JIF (lbs) = 0.000526 × MW (ppg) × Q (gpm) × Vn (ft/s)
+    ```
+    Where:
+    - JIF = Jet Impact Force in pounds
+    - MW = Mud Weight in pounds per gallon (converted from SG if necessary)
+    - Q = Flow Rate in gallons per minute
+    - Vn = Nozzle Velocity in feet per second (as calculated in the previous step)
+
+This feature has been implemented in the calculator, providing users with another key hydraulic parameter for analysis and optimization of drilling operations.
 
 ## Installation
 
@@ -72,15 +100,18 @@ The application will be available at `http://localhost:5000` in your web browser
 ## Usage
 
 1. Enter the required inputs:
-   - Nozzle sizes (in 32nds of an inch)
-   - Mud weight/density
-   - Flow rate
-   - Bit size
+   - Nozzle sizes (in 32nds of an inch) or Direct TFA
+   - Mud weight/density (ppg or SG)
+   - Flow rate (GPM) - single value or a range (e.g., 800 or 800-1200)
+   - Bit size (inches)
 
 2. The calculator will automatically compute:
    - Total Flow Area (TFA)
-   - Pressure loss through nozzles
+   - Pressure loss through nozzles (PSI)
    - HSI value
+   - Jet Impact Force (lbs)
+
+For range inputs, charts will be displayed for Pressure Loss, HSI, and Jet Impact Force versus Flow Rate.
 
 ## License
 
@@ -90,6 +121,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - Primary reference: "Formulas and Calculations for Drilling, Production, and Workover" by Norton J. Lapeyrouse
 - Icons and graphics: Various open-source contributors
-
-
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -303,7 +303,7 @@
             return options;
         }
 
-        function addNozzleRow() {
+        function addNozzleRow(size = '', quantity = '') { // Accept optional size and quantity
             const container = document.getElementById('nozzleInputs');
             const nozzleCount = container.children.length;
             
@@ -326,12 +326,20 @@
                     </select>
                 </div>
                 <div class="col-2">
-                    <button type="button" class="btn btn-danger btn-sm" onclick="this.closest('.nozzle-row').remove()">
+                    <button type="button" class="btn btn-danger btn-sm" onclick="this.closest('.nozzle-row').remove(); saveFormData();">
                         ×
                     </button>
                 </div>
             `;
             
+            // If size and quantity are provided (during restore), set them
+            if (size) {
+                row.querySelector('.nozzle-size').value = size;
+            }
+            if (quantity) {
+                row.querySelector('.nozzle-quantity').value = quantity;
+            }
+
             container.appendChild(row);
         }
 


### PR DESCRIPTION
- I modified the `addNozzleRow` JavaScript function to correctly accept and set size/quantity parameters. This ensures that nozzle data saved in local storage is properly restored when you load the page.
- I also made sure `saveFormData` is called when nozzle rows are removed.

Docs: Update README with Jet Impact Force details

- I added a dedicated section for Jet Impact Force (JIF) in `README.md`.
- I detailed the formulas used for Nozzle Velocity and JIF calculations.
- I updated the 'Overview' and 'Usage' sections to include JIF.